### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/example.mjs
+++ b/example.mjs
@@ -30,7 +30,7 @@ const q = new NotificationQueue('/tmp/a-queue', async function (incoming) {
   q.suspend()
 })
 
-const data = await hc.core.tree.proof({
+const data = await hc.proof({
   block: { index: 0, nodes: 0 },
   upgrade: { start: 0, length: hc.length }
 })

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "description": "Store a bunch of Hypercore proofs to a file and consume them later",
   "dependencies": {
-    "compact-encoding": "^2.15.0",
+    "compact-encoding": "^3.0.0",
     "fifofile": "^2.0.0",
     "hypercore": "^11.0.0"
   }


### PR DESCRIPTION
Repo currently doesn't have tests, but the `example.mjs` (once a bug is fixed in this commit 2fadf52) runs.